### PR TITLE
Increase discover characteristics timeout

### DIFF
--- a/pygatt/backends/gatttool/gatttool.py
+++ b/pygatt/backends/gatttool/gatttool.py
@@ -234,7 +234,7 @@ class GATTToolBackend(BLEBackend):
         with self._connection_lock:
             self._con.sendline('characteristics')
 
-            timeout = 2
+            timeout = 6
             while True:
                 try:
                     self._con.expect(


### PR DESCRIPTION
In most cases two seconds not enough for reading all characteristics
from BLE device. For example, when there is non-ideal conditions for
connectivity and/or a lot of characteristics, in my case I couldn't read
them from TI SensorTag.